### PR TITLE
Fixed cmake for using pe_lib as subproject

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,11 +2,13 @@ cmake_minimum_required(VERSION 2.8)
 
 #common properties
 
+project(pe_lib_root)
+
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build, options are: Debug Release" FORCE)
 endif ()
 
-set(ROOT "${CMAKE_SOURCE_DIR}/..")
+set(ROOT "${CMAKE_CURRENT_SOURCE_DIR}/..")
 set(OBJ_DIR "${ROOT}/obj/${CMAKE_BUILD_TYPE}")
 set(LIB_DIR "${ROOT}/lib/${CMAKE_BUILD_TYPE}")
 set(BIN_DIR "${ROOT}/bin/${CMAKE_BUILD_TYPE}")

--- a/src/pe_lib/CMakeLists.txt
+++ b/src/pe_lib/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT pe_lib)
    
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_library(${PROJECT} STATIC ${HEADERS} ${SOURCES})

--- a/src/samples/address_convertions/CMakeLists.txt
+++ b/src/samples/address_convertions/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT address_convertions)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/basic_dotnet_viewer/CMakeLists.txt
+++ b/src/samples/basic_dotnet_viewer/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT basic_dotnet_viewer)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/basic_info_viewer/CMakeLists.txt
+++ b/src/samples/basic_info_viewer/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT basic_info_viewer)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/bound_import_reader/CMakeLists.txt
+++ b/src/samples/bound_import_reader/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT bound_import_reader)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/debug_info_reader/CMakeLists.txt
+++ b/src/samples/debug_info_reader/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT debug_info_reader)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/entropy_calculator/CMakeLists.txt
+++ b/src/samples/entropy_calculator/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT entropy_calculator)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/exception_dir_reader/CMakeLists.txt
+++ b/src/samples/exception_dir_reader/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT exception_dir_reader)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/export_adder/CMakeLists.txt
+++ b/src/samples/export_adder/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT export_adder)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/exports_reader/CMakeLists.txt
+++ b/src/samples/exports_reader/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT exports_reader)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/full_pe_rebuilder/CMakeLists.txt
+++ b/src/samples/full_pe_rebuilder/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT full_pe_rebuilder)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/image_config_editor/CMakeLists.txt
+++ b/src/samples/image_config_editor/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT image_config_editor)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/import_adder/CMakeLists.txt
+++ b/src/samples/import_adder/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT import_adder)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/imports_reader/CMakeLists.txt
+++ b/src/samples/imports_reader/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT imports_reader)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/pe_config_reader/CMakeLists.txt
+++ b/src/samples/pe_config_reader/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT pe_config_reader)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/pe_realigner/CMakeLists.txt
+++ b/src/samples/pe_realigner/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT pe_realigner)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/pe_rebaser/CMakeLists.txt
+++ b/src/samples/pe_rebaser/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT pe_rebaser)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/pe_sections_reader/CMakeLists.txt
+++ b/src/samples/pe_sections_reader/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT pe_sections_reader)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/pe_stripper/CMakeLists.txt
+++ b/src/samples/pe_stripper/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT pe_stripper)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/relocation_adder/CMakeLists.txt
+++ b/src/samples/relocation_adder/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT relocation_adder)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/relocations_reader/CMakeLists.txt
+++ b/src/samples/relocations_reader/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT relocations_reader)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/resource_editor/CMakeLists.txt
+++ b/src/samples/resource_editor/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT resource_editor)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/resource_viewer/CMakeLists.txt
+++ b/src/samples/resource_viewer/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT resource_viewer)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/rich_overlay_stub_reader/CMakeLists.txt
+++ b/src/samples/rich_overlay_stub_reader/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT rich_overlay_stub_reader)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/section_adder/CMakeLists.txt
+++ b/src/samples/section_adder/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT section_adder)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/sections_and_addresses/CMakeLists.txt
+++ b/src/samples/sections_and_addresses/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT sections_and_addresses)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/tls_editor/CMakeLists.txt
+++ b/src/samples/tls_editor/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT tls_editor)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/samples/tls_reader/CMakeLists.txt
+++ b/src/samples/tls_reader/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT tls_reader)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 

--- a/src/tests/test_bound_import/CMakeLists.txt
+++ b/src/tests/test_bound_import/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_bound_import)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_checksum/CMakeLists.txt
+++ b/src/tests/test_checksum/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_checksum)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_debug/CMakeLists.txt
+++ b/src/tests/test_debug/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_debug)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_dotnet/CMakeLists.txt
+++ b/src/tests/test_dotnet/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_dotnet)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_entropy/CMakeLists.txt
+++ b/src/tests/test_entropy/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_entropy)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_exception_directory/CMakeLists.txt
+++ b/src/tests/test_exception_directory/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_exception_directory)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_exports/CMakeLists.txt
+++ b/src/tests/test_exports/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_exports)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_imports/CMakeLists.txt
+++ b/src/tests/test_imports/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_imports)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_load_config/CMakeLists.txt
+++ b/src/tests/test_load_config/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_load_config)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_relocations/CMakeLists.txt
+++ b/src/tests/test_relocations/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_relocations)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_resource_bitmap/CMakeLists.txt
+++ b/src/tests/test_resource_bitmap/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_resource_bitmap)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_resource_icon_cursor/CMakeLists.txt
+++ b/src/tests/test_resource_icon_cursor/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_resource_icon_cursor)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_resource_manager/CMakeLists.txt
+++ b/src/tests/test_resource_manager/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_resource_manager)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_resource_message_table/CMakeLists.txt
+++ b/src/tests/test_resource_message_table/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_resource_message_table)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
 
 target_link_libraries(${PROJECT} PUBLIC pe_lib)
 

--- a/src/tests/test_resource_string_table/CMakeLists.txt
+++ b/src/tests/test_resource_string_table/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_resource_string_table)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_resource_version_info/CMakeLists.txt
+++ b/src/tests/test_resource_version_info/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_resource_version_info)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_resource_viewer/CMakeLists.txt
+++ b/src/tests/test_resource_viewer/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_resource_viewer)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_resources/CMakeLists.txt
+++ b/src/tests/test_resources/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_resources)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_rich_data/CMakeLists.txt
+++ b/src/tests/test_rich_data/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_rich_data)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_runner/CMakeLists.txt
+++ b/src/tests/test_runner/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_runner)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/test_tls/CMakeLists.txt
+++ b/src/tests/test_tls/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT test_tls)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/tests_basic/CMakeLists.txt
+++ b/src/tests/tests_basic/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT tests_basic)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 

--- a/src/tests/tests_utils/CMakeLists.txt
+++ b/src/tests/tests_utils/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 set(PROJECT tests_utils)
 
-include (${CMAKE_SOURCE_DIR}/config.cmake)
+include (${pe_lib_root_SOURCE_DIR}/config.cmake)
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
 
-target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/tests/)
+target_include_directories(${PROJECT} PRIVATE ${pe_lib_SOURCE_DIR} ${pe_lib_root_SOURCE_DIR}/tests/)
     
 target_link_libraries(${PROJECT} PRIVATE pe_lib)
 


### PR DESCRIPTION
Added root project and replaced CMAKE_SRC_DIR with macro that use root project name.